### PR TITLE
Replace [] with array() for php 5.3 compatibility

### DIFF
--- a/src/FreshMail/RestApi.php
+++ b/src/FreshMail/RestApi.php
@@ -43,7 +43,7 @@ class RestApi
     /**
      * @var array
      */
-    private $errors = [];
+    private $errors = array();
 
     /**
      * Get errors.
@@ -131,7 +131,7 @@ class RestApi
         return $this;
     }
 
-    public function doRequest($strUrl, $arrParams = [], $returnRawResponse = false)
+    public function doRequest($strUrl, $arrParams = array(), $returnRawResponse = false)
     {
         if (empty($arrParams)) {
             $strPostData = '';
@@ -143,7 +143,7 @@ class RestApi
 
         $apiSignature = sha1($this->strApiKey . '/' . self::PREFIX . $strUrl . $strPostData . $this->strApiSecret);
 
-        $headers = [];
+        $headers = array();
         $headers[] = 'X-Rest-ApiKey: ' . $this->strApiKey;
         $headers[] = 'X-Rest-ApiSign: ' . $apiSignature;
 
@@ -199,9 +199,9 @@ class RestApi
             preg_match('/filename\=\"([a-zA-Z0-9\.]+)\"/', $headers, $fileName);
             file_put_contents(self::DEFAULT_FILE_PATH . $fileName[1], substr($this->rawResponse, $headerSize));
 
-            $this->response = [
+            $this->response = array(
                 'path' => self::DEFAULT_FILE_PATH . $fileName[1]
-            ];
+            );
         } else {
             $this->response = json_decode(substr($this->rawResponse, $headerSize), true);
         }


### PR DESCRIPTION
Musiałem uruchomić serwis z waszą biblioteką na serwerze na którym jest PHP w wersji 5.3.10. Pomimo zapewnień w pliku composer.json, że biblioteka działa od wersji 5.3.0 występowały błędy. Ten PR powinien naprawić działanie biblioteki na tej wersji PHP, ale przetestowałem tylko dodawanie nowych adresów. Trzeba również w przykładach zmienić definicje tablic.